### PR TITLE
feat: konvoy multi provisioner

### DIFF
--- a/cluster-autoscaler/cloudprovider/konvoy/konvoy.go
+++ b/cluster-autoscaler/cloudprovider/konvoy/konvoy.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	kommanderv1beta1 "github.com/mesosphere/kommander-cluster-lifecycle/clientapis/pkg/apis/kommander/v1beta1"
-	konvoyconstants "github.com/mesosphere/konvoy/clientapis/pkg/constants"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -100,7 +99,7 @@ func (konvoy *KonvoyCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprov
 		return nil, nil
 	}
 
-	nodeName := kubernetesNodeName(node, konvoy.konvoyManager.provisioner)
+	nodeName := kubernetesNodeName(node)
 	nodeGroupName, err := konvoy.konvoyManager.GetNodeGroupNameForNode(nodeName)
 	if err != nil {
 		return nil, err
@@ -169,7 +168,6 @@ func BuildKonvoy(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDisco
 
 	externalClient := kubeclient.NewForConfigOrDie(externalConfig)
 	konvoyManager := &KonvoyManager{
-		provisioner:      konvoyconstants.ProvisionerAWS,
 		dynamicClient:    dynamicClient,
 		clusterName:      opts.ClusterName,
 		clusterNamespace: konvoyOpts.Namespace,

--- a/cluster-autoscaler/cloudprovider/konvoy/konvoy_manager.go
+++ b/cluster-autoscaler/cloudprovider/konvoy/konvoy_manager.go
@@ -152,6 +152,13 @@ func (k *KonvoyManager) setNodeGroupTargetSize(nodeGroupName string, newSize int
 		err = k.dynamicClient.Get(context.Background(), clusterNamespacedName, konvoyCluster)
 		if err != nil {
 			klog.Warningf("Error retrieving the konvoy cluster: %v -- %v", konvoyCluster.Name, err)
+			return err
+		}
+
+		// When Konvoy cluster is paused or in a provisioning phase. Let's skip any change for now
+		if konvoyCluster.Spec.ProvisioningPaused || konvoyCluster.Status.Phase == kommanderv1beta1.KonvoyClusterPhaseProvisioning {
+			klog.Errorf("Konvoy cluster is paused or in provisioning phase, retrying...")
+			return fmt.Errorf("Konvoy cluster is paused or in provisioning phase, retrying...")
 		}
 
 		targetPoolIndex := -1
@@ -228,7 +235,7 @@ func (k *KonvoyManager) RemoveNodeFromNodeGroup(nodeGroupName string, nodeName s
 	}
 
 	decreasedTargetSize := currentTargetSize - 1
-	klog.Info(
+	klog.Infof(
 		"Removing node `%s` from node group `%s` by decreasing pool size to `%d`",
 		nodeName, nodeGroupName, decreasedTargetSize)
 

--- a/cluster-autoscaler/cloudprovider/konvoy/konvoy_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/konvoy/konvoy_manager_test.go
@@ -16,7 +16,6 @@ import (
 	kclv1beta1 "github.com/mesosphere/kommander-cluster-lifecycle/clientapis/pkg/apis/kommander/v1beta1"
 	konvoyclusterv1beta1 "github.com/mesosphere/kommander-cluster-lifecycle/clientapis/pkg/apis/kommander/v1beta1"
 	konvoyv1beta1 "github.com/mesosphere/konvoy/clientapis/pkg/apis/konvoy/v1beta1"
-	konvoyconstants "github.com/mesosphere/konvoy/clientapis/pkg/constants"
 )
 
 func TestKonvoyManagerGetNodeGroups(t *testing.T) {
@@ -93,7 +92,6 @@ func TestKonvoyManagerGetNodeGroups(t *testing.T) {
 		dynamicClient := fake.NewFakeClientWithScheme(scheme, test.konvoyCluster)
 
 		mgr := &KonvoyManager{
-			provisioner:   konvoyconstants.ProvisionerAWS,
 			dynamicClient: dynamicClient,
 			clusterName:   test.clusterName,
 		}
@@ -157,7 +155,6 @@ func TestKonvoyManagerSetTargetSizeIgnored(t *testing.T) {
 		dynamicClient := fake.NewFakeClientWithScheme(scheme, test.konvoyCluster)
 
 		mgr := &KonvoyManager{
-			provisioner:   konvoyconstants.ProvisionerAWS,
 			dynamicClient: dynamicClient,
 			clusterName:   test.clusterName,
 		}
@@ -183,7 +180,6 @@ func TestKonvoyManagerGetNodeNamesForNodeGroup(t *testing.T) {
 		expectedNodes []string
 		node          *corev1.Node
 		nodeGroup     string
-		provisioner   string
 	}{
 		{
 			description:   "should return empty node names list",
@@ -219,7 +215,6 @@ func TestKonvoyManagerGetNodeNamesForNodeGroup(t *testing.T) {
 					ProviderID: "test-provider-id",
 				},
 			},
-			provisioner: konvoyconstants.ProvisionerAWS,
 		},
 		{
 			description:   "should return empty list because node does not have required label",
@@ -251,7 +246,6 @@ func TestKonvoyManagerGetNodeNamesForNodeGroup(t *testing.T) {
 
 		mgr := &KonvoyManager{
 			kubeClient:  kubeClient,
-			provisioner: test.provisioner,
 		}
 
 		if test.err != nil {

--- a/cluster-autoscaler/cloudprovider/konvoy/konvoy_node_group.go
+++ b/cluster-autoscaler/cloudprovider/konvoy/konvoy_node_group.go
@@ -61,7 +61,7 @@ func (nodeGroup *NodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
 	for _, node := range nodes {
-		nodeName := kubernetesNodeName(node, nodeGroup.konvoyManager.provisioner)
+		nodeName := kubernetesNodeName(node)
 		if err := nodeGroup.konvoyManager.RemoveNodeFromNodeGroup(nodeGroup.Name, nodeName); err != nil {
 			return err
 		}

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-querystring v1.0.0
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/json-iterator/go v1.1.9
-	github.com/mesosphere/kommander-cluster-lifecycle/clientapis v0.0.0-20200310195319-9ade9d29b183
+	github.com/mesosphere/kommander-cluster-lifecycle/clientapis v0.0.0-20200323150606-ab6f57ecf9a3
 	github.com/mesosphere/konvoy/clientapis v0.0.0
 	github.com/prometheus/client_golang v1.1.0
 	github.com/satori/go.uuid v1.2.0
@@ -28,8 +28,8 @@ require (
 	google.golang.org/api v0.9.0
 	gopkg.in/gcfg.v1 v1.2.0
 	gopkg.in/yaml.v2 v2.2.8
-	k8s.io/api v0.17.3
-	k8s.io/apimachinery v0.17.3
+	k8s.io/api v0.17.4
+	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/cloud-provider v0.16.4
 	k8s.io/component-base v0.17.3
@@ -38,7 +38,7 @@ require (
 	k8s.io/legacy-cloud-providers v0.0.0
 	k8s.io/metrics v0.16.4
 	k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab
-	sigs.k8s.io/controller-runtime v0.5.1-0.20200307095134-d0de78d9f1c1
+	sigs.k8s.io/controller-runtime v0.5.1
 )
 
 replace (
@@ -342,7 +342,7 @@ replace github.com/mesosphere/konvoy/clientapis => github.com/mesosphere/konvoy/
 
 replace github.com/google/go-querystring => github.com/google/go-querystring v1.0.0
 
-replace github.com/mesosphere/kommander-cluster-lifecycle/clientapis => github.com/mesosphere/kommander-cluster-lifecycle/clientapis v0.0.0-20200310195319-9ade9d29b183
+replace github.com/mesosphere/kommander-cluster-lifecycle/clientapis => github.com/mesosphere/kommander-cluster-lifecycle/clientapis v0.0.0-20200323150606-ab6f57ecf9a3
 
 replace k8s.io/helm => k8s.io/helm v2.16.3+incompatible
 

--- a/cluster-autoscaler/go.mod-extra
+++ b/cluster-autoscaler/go.mod-extra
@@ -17,7 +17,7 @@ replace (
   golang.org/x/net => github.com/golang/net v0.0.0-20191105084925-a882066a44e0
   github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v34.0.0+incompatible
   github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.0.0
-  github.com/mesosphere/kommander-cluster-lifecycle/clientapis => github.com/mesosphere/kommander-cluster-lifecycle/clientapis v0.0.0-20200310195319-9ade9d29b183
+  github.com/mesosphere/kommander-cluster-lifecycle/clientapis => github.com/mesosphere/kommander-cluster-lifecycle/clientapis v0.0.0-20200323150606-ab6f57ecf9a3
   github.com/mesosphere/konvoy => github.com/mesosphere/konvoy v1.4.1-0.20200310090954-4cd2e24282f1
 	github.com/mesosphere/konvoy/clientapis => github.com/mesosphere/konvoy/clientapis v0.0.0-20200310090954-4cd2e24282f1
 )

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -327,8 +327,11 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mesos/mesos-go v0.0.9/go.mod h1:kPYCMQ9gsOXVAle1OsoY4I1+9kPu8GHkf88aV59fDr4=
 github.com/mesosphere/dex-controller v0.2.0/go.mod h1:VpzH+Du3ApdzJ/o5pXQvOo16N2Qqhp5q4CIYo7yI2vg=
+github.com/mesosphere/kommander-cluster-lifecycle v0.5.2 h1:H7n7x8SmO4cUfghSQF1RXnffM+N0yt6TSiqYfxi95VI=
 github.com/mesosphere/kommander-cluster-lifecycle/clientapis v0.0.0-20200310195319-9ade9d29b183 h1:3cblcGCa/0zp5vVAPkWDMAxV/oT+IvGekTWONuum/lY=
 github.com/mesosphere/kommander-cluster-lifecycle/clientapis v0.0.0-20200310195319-9ade9d29b183/go.mod h1:Dc4SSD8AJGrX5NU/+WcQWntxVjVYwq8lXAfd4oXsQTM=
+github.com/mesosphere/kommander-cluster-lifecycle/clientapis v0.0.0-20200323150606-ab6f57ecf9a3 h1:xMBgIREe7aKW76xgum1QGtRBiYF6mrJ23RON0VHO6vA=
+github.com/mesosphere/kommander-cluster-lifecycle/clientapis v0.0.0-20200323150606-ab6f57ecf9a3/go.mod h1:UdmG1bQhSzQxMXaIdi5TVarSa9vHpJzfMsGJgg6LGIE=
 github.com/mesosphere/konvoy v1.4.1-0.20200310090954-4cd2e24282f1 h1:dTv5nQLrGqQ30wiTRnmrjmWusJ3dzdXHeodf6nL5jjA=
 github.com/mesosphere/konvoy v1.4.1-0.20200310090954-4cd2e24282f1/go.mod h1:nNJbPNxRHU1pclsu6lpxxfJOt5kVFkpvS3LBJWtojRQ=
 github.com/mesosphere/konvoy/clientapis v0.0.0-20200310090954-4cd2e24282f1 h1:lfk5ZwDsE4OKwy4Fd7SN3Cd0dqgDsctWbIgoXxiwXO0=
@@ -630,6 +633,8 @@ sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZw
 sigs.k8s.io/controller-runtime v0.5.0/go.mod h1:REiJzC7Y00U+2YkMbT8wxgrsX5USpXKGhb2sCtAXiT8=
 sigs.k8s.io/controller-runtime v0.5.1-0.20200307095134-d0de78d9f1c1 h1:GolnBOlK7B/TxbPY3766BY6N+nsHzc/XHfxdCy7OuKs=
 sigs.k8s.io/controller-runtime v0.5.1-0.20200307095134-d0de78d9f1c1/go.mod h1:Uojny7gvg55YLQnEGnPzRE3dC4ik2tRlZJgOUCWXAV4=
+sigs.k8s.io/controller-runtime v0.5.1 h1:TNidCfVoU/cs2i+9xoTcL/l7yhl0bDhYXU0NCG6wmiE=
+sigs.k8s.io/controller-runtime v0.5.1/go.mod h1:Uojny7gvg55YLQnEGnPzRE3dC4ik2tRlZJgOUCWXAV4=
 sigs.k8s.io/controller-tools v0.2.0-beta.4/go.mod h1:8t/X+FVWvk6TaBcsa+UKUBbn7GMtvyBKX30SGl4em6Y=
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/kind v0.6.1/go.mod h1:dhW5h0O4PRVq8B6eExphIa9mBnrlBzxEz3R/P1YcYj0=


### PR DESCRIPTION
Add support to use other provisioners than AWS, such as Azure and GCP.