### PR TITLE
test: fix unit tests

### DIFF
--- a/cluster-autoscaler/Dockerfile.ci
+++ b/cluster-autoscaler/Dockerfile.ci
@@ -1,0 +1,18 @@
+FROM golang:1.13.10
+
+ENV HOME=/tmp
+
+ENV GO111MODULE on
+ENV GOPRIVATE github.com/mesosphere
+
+RUN apt-get update && apt-get install -y \
+    libseccomp-dev -qq \
+    locales \
+    unzip \
+    dnsutils \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler
+WORKDIR $GOPATH/src/k8s.io/autoscaler/cluster-autoscaler

--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -21,6 +21,12 @@ else
   LDFLAGS_FLAG=
 endif
 
+# D2iQ Release build to push a mesosphere image for the
+KUBERNETES_VERSION?=1.16
+D2IQ_TAG_VERSION?=v$(KUBERNETES_VERSION)-0.1.0
+d2iq-docker-release:
+	TAG=$(D2IQ_TAG_VERSION) GOOS=linux REGISTRY=mesosphere PROVIDER= $(MAKE) build build-binary execute-release
+
 build: clean deps
 	$(ENVVAR) GOOS=$(GOOS) go build ${LDFLAGS_FLAG} ${TAGS_FLAG} ./...
 	$(ENVVAR) GOOS=$(GOOS) go build -o cluster-autoscaler ${LDFLAGS_FLAG} ${TAGS_FLAG}
@@ -73,4 +79,3 @@ test-in-docker: clean docker-builder
 	docker run -v `pwd`:/gopath/src/k8s.io/autoscaler/cluster-autoscaler/ autoscaling-builder:latest bash -c 'cd /gopath/src/k8s.io/autoscaler/cluster-autoscaler && go test -race ./... ${TAGS_FLAG}'
 
 .PHONY: all deps build test-unit clean format execute-release dev-release docker-builder build-in-docker release generate
-

--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -3,7 +3,7 @@ all: build
 TAG?=dev
 FLAGS=
 LDFLAGS?=-s
-ENVVAR=CGO_ENABLED=0
+ENVVAR ?= CGO_ENABLED=0
 GOOS?=linux
 REGISTRY?=staging-k8s.gcr.io
 ifdef BUILD_TAGS
@@ -21,11 +21,7 @@ else
   LDFLAGS_FLAG=
 endif
 
-# D2iQ Release build to push a mesosphere image for the
-KUBERNETES_VERSION?=1.16
-D2IQ_TAG_VERSION?=v$(KUBERNETES_VERSION)-0.1.0
-d2iq-docker-release:
-	TAG=$(D2IQ_TAG_VERSION) GOOS=linux REGISTRY=mesosphere PROVIDER= $(MAKE) build build-binary execute-release
+include d2iq.mk
 
 build: clean deps
 	$(ENVVAR) GOOS=$(GOOS) go build ${LDFLAGS_FLAG} ${TAGS_FLAG} ./...

--- a/cluster-autoscaler/core/scale_down_test.go
+++ b/cluster-autoscaler/core/scale_down_test.go
@@ -625,13 +625,20 @@ func TestDeleteNode(t *testing.T) {
 			assert.Equal(t, nothingReturned, getStringFromChanImmediately(deletedNodes))
 			assert.Equal(t, scenario.expectedResultType, result.ResultType)
 
-			taintedUpdate := fmt.Sprintf("%s-%s", n1.Name, []string{deletetaint.ToBeDeletedTaint})
+			// TODO(d2iq): This is commented out because Konvoy autoscaler plugin cannot
+			// target deletion of particular node while autoscaler expects particular node
+			// to be deleted. Since Konvoy plugin will delete "random" node we rather not
+			// evict pods from processed node.
+			// Once konvoy plugin supports deletion of specific nodes (when switched to
+			// cluster api) this code should be uncommented.
+			/* taintedUpdate := fmt.Sprintf("%s-%s", n1.Name, []string{deletetaint.ToBeDeletedTaint})
 			assert.Equal(t, taintedUpdate, getStringFromChan(updatedNodes))
 			if !scenario.expectedDeletion {
 				untaintedUpdate := fmt.Sprintf("%s-%s", n1.Name, []string{})
 				assert.Equal(t, untaintedUpdate, getStringFromChanImmediately(updatedNodes))
 			}
 			assert.Equal(t, nothingReturned, getStringFromChanImmediately(updatedNodes))
+			*/
 		})
 	}
 }
@@ -953,7 +960,15 @@ func TestScaleDown(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, status.ScaleDownNodeDeleteStarted, scaleDownStatus.Result)
 	assert.Equal(t, n1.Name, getStringFromChan(deletedNodes))
-	assert.Equal(t, n1.Name, getStringFromChan(updatedNodes))
+
+	// TODO(d2iq): This is commented out because Konvoy autoscaler plugin cannot
+	// target deletion of particular node while autoscaler expects particular node
+	// to be deleted. Since Konvoy plugin will delete "random" node we rather not
+	// evict pods from processed node.
+	// Once konvoy plugin supports deletion of specific nodes (when switched to
+	// cluster api) this code should be uncommented.
+	//
+	// assert.Equal(t, n1.Name, getStringFromChan(updatedNodes))
 }
 
 func waitForDeleteToFinish(t *testing.T, sd *ScaleDown) {

--- a/cluster-autoscaler/d2iq.mk
+++ b/cluster-autoscaler/d2iq.mk
@@ -1,0 +1,51 @@
+# D2iQ Release build to push a mesosphere image for the
+KUBERNETES_VERSION?=1.16
+D2IQ_TAG_VERSION?=v$(KUBERNETES_VERSION)-0.1.0
+
+PKG = k8s.io/autoscaler/cluster-autoscaler
+
+# DOCKER_IMG_TAG is the tag of the builder image based on the go.sum and Dockerfile and additional build-args that are passed, that otherwise don't change the sha of the Dockerfile
+GO_MOD_SHASUM := $$(shasum go.sum | awk '{ print $$1 }' | cut -c1-3)
+GO_VERSION = 1.13.8
+KUBERNETES_VERSION_SHASUM = $$(echo $(KUBERNETES_VERSION) | shasum | awk '{ print $$1 }' | cut -c1-3)
+GO_VERSION_SHASUM = $$(echo $(GO_VERSION) | shasum | awk '{ print $$1 }' | cut -c1-3)
+DOCKERFILE_SHASUM := $$(shasum ./Dockerfile.ci | awk '{ print $$1 }' | cut -c1-3)
+DOCKER_IMG_TAG := $(shell echo $(DOCKERFILE_SHASUM)$(GO_MOD_SHASUM)$(GO_VERSION_SHASUM)$(KUBERNETES_VERSION_SHASUM))
+DOCKER_CI_IMG := mesosphere/cluster-autoscaler:$(DOCKER_IMG_TAG)
+
+.PHONY: d2iq-docker-release
+d2iq-docker-release:
+	TAG=$(D2IQ_TAG_VERSION) GOOS=linux REGISTRY=mesosphere PROVIDER= $(MAKE) build build-binary execute-release
+
+
+.PHONY: docker-ci.builder
+docker-ci.builder:
+ifeq ($(shell docker image list -q $(DOCKER_CI_IMG)),)
+	docker build                                              \
+	    --build-arg KUBERNETES_VERSION=v$(KUBERNETES_VERSION) \
+	    -f Dockerfile.ci -t $(DOCKER_CI_IMG) .
+endif
+
+
+.PHONY: gitauth
+gitauth:
+ifeq ($(CI),yes)
+ifdef GITHUB_TOKEN
+	@git config --global url."https://$(GITHUB_TOKEN):x-oauth-basic@github.com/mesosphere".insteadOf "https://github.com/mesosphere"
+endif
+endif
+
+.PHONY: docker-ci.test-unit
+docker-ci.test-unit: docker-ci.builder
+	echo Running test in a container;                       \
+	docker run                                          	  \
+			--rm                                                \
+			--net=host                                          \
+			-e ENVVAR=$(ENVVAR)                                 \
+			-e GITHUB_TOKEN=$(GITHUB_TOKEN)                     \
+			-e CI="$(CI)"                                       \
+			-v "$(shell pwd)":"$(HOME)/src/$(PKG)"              \
+			-v "/tmp/":"/tmp"                                   \
+	    -w $(HOME)/src/$(PKG)                               \
+	    $(DOCKER_CI_IMG)                                     \
+	    make gitauth test-unit


### PR DESCRIPTION
```
➜  cluster-autoscaler git:(konvoy/cluster-autoscaler-release-1.16) ✗  go test --test.short -race ./...
ok  	k8s.io/autoscaler/cluster-autoscaler	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud	(cached)
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth/credentials	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/auth/signers	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/endpoints	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/errors	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/requests	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/responses	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/sdk/utils	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/services/ecs	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/alibaba-cloud-sdk-go/services/ess	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud/metadata	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud	(cached)
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/bcc	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/bce	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/billing	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/blb	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/cce	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/clientset	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/eip	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/util	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud/baiducloud-sdk-go/vpc	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/digitalocean	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/digitalocean/godo	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/konvoy	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum	(cached)
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/blockstorage/extensions/volumeactions	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/blockstorage/v1/volumes	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/blockstorage/v2/volumes	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/blockstorage/v3/volumes	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/common/extensions	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/extensions/attachinterfaces	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/extensions/volumeattach	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/flavors	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/images	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/compute/v2/servers	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/containerinfra/v1/clusters	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/identity/v2/tenants	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/identity/v2/tokens	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/identity/v3/extensions/trusts	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/identity/v3/tokens	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/networking/v2/extensions	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/networking/v2/extensions/external	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/networking/v2/extensions/layer3/floatingips	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/networking/v2/extensions/layer3/routers	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/networking/v2/extensions/lbaas_v2/l7policies	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/networking/v2/extensions/security/groups	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/networking/v2/extensions/security/rules	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/networking/v2/networks	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/networking/v2/ports	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/orchestration/v1/stackresources	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/orchestration/v1/stacks	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/utils	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/pagination	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/testhelper	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/mocks	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/packet	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/cloudprovider/test	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/clusterstate	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/clusterstate/api	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/clusterstate/utils	(cached)
?   	k8s.io/autoscaler/cluster-autoscaler/config	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/config/dynamic	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/context	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/core	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/estimator	(cached)
?   	k8s.io/autoscaler/cluster-autoscaler/expander	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/expander/factory	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/expander/mostpods	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/expander/price	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/expander/priority	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/expander/random	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/expander/waste	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/metrics	(cached)
?   	k8s.io/autoscaler/cluster-autoscaler/processors	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/processors/callbacks	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/processors/nodegroups	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/processors/nodegroupset	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/processors/nodes	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/processors/pods	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/processors/status	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/simulator	(cached)
?   	k8s.io/autoscaler/cluster-autoscaler/utils	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/backoff	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/daemonset	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/deletetaint	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/drain	(cached)
?   	k8s.io/autoscaler/cluster-autoscaler/utils/errors	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/glogx	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/gpu	(cached)
?   	k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/labels	(cached)
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/scheduler	(cached)
?   	k8s.io/autoscaler/cluster-autoscaler/utils/test	[no test files]
ok  	k8s.io/autoscaler/cluster-autoscaler/utils/tpu	(cached)
?   	k8s.io/autoscaler/cluster-autoscaler/utils/units	[no test files]
?   	k8s.io/autoscaler/cluster-autoscaler/version	[no test files]
```