### PR TITLE
deepCopyNodeInfo succeeded; update cache

### DIFF
--- a/cluster-autoscaler/core/utils.go
+++ b/cluster-autoscaler/core/utils.go
@@ -301,7 +301,6 @@ func getNodeInfosForGroups(nodes []*apiv1.Node, nodeInfoCache map[string]*schedu
 		}
 		if added && nodeInfoCache != nil {
 			if nodeInfoCopy, err := deepCopyNodeInfo(result[id]); err == nil {
-				klog.Errorf("Error while deep copying node info: %v", err)
 				nodeInfoCache[id] = nodeInfoCopy
 			}
 		}


### PR DESCRIPTION
This is not an error. The if statement checks to see that the copy succeeded. If it did, it updates the cache.